### PR TITLE
chore(back): setup VSC for backend debug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "name": "Debug API",
+      "cwd": "${workspaceFolder}/back",
+      "request": "launch",
+      "restart": true,
+      "presentation": {
+        "hidden": false,
+        "group": "Backend",
+        "order": 1
+      },
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node"
+    }
+  ]
+}


### PR DESCRIPTION
## Details

Add launch setup to start a dev runtime for the backend and connect it to the VSCode debugger.