### PR TITLE
fix(auth): return unauth error on JWT expiration

### DIFF
--- a/back/server/api/v1/auth/middlewares.js
+++ b/back/server/api/v1/auth/middlewares.js
@@ -28,6 +28,9 @@ exports.me = async (req, _, next) => {
     req.me = me;
     return next();
   } catch (err) {
+    if (err.message === 'jwt expired') {
+      return next(UnauthorizedErrorResponse('Session expired'));
+    }
     if (err.message === 'jwt malformed') {
       return next(UnauthorizedErrorResponse('Invalid access token'));
     }


### PR DESCRIPTION
## Details

Return an unauthorized error when the JWT has expired.